### PR TITLE
Release/1.0.6

### DIFF
--- a/.github/scripts/git_flow.py
+++ b/.github/scripts/git_flow.py
@@ -8,7 +8,7 @@ import nltk
 from fastcore.net import HTTP401UnauthorizedError, HTTP403ForbiddenError
 from ghapi.all import GhApi
 
-__version__ = '1.0.5'
+__version__ = '1.0.6'
 api = GhApi()
 
 

--- a/.github/workflows/gitflow.yml
+++ b/.github/workflows/gitflow.yml
@@ -19,7 +19,7 @@ jobs:
   enforce-git-flow:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python 3
         uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 
 ## Unreleased
 
+### Build
+
+* Bump actions/checkout from 6 to 7. [dependabot[bot]]
+
+  Bumps [actions/checkout](https://github.com/actions/checkout) from 6 to 7.
+  - [Release notes](https://github.com/actions/checkout/releases)
+  - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
+  - [Commits](https://github.com/actions/checkout/compare/v6...v7)
+
+  ---
+  updated-dependencies:
+  - dependency-name: actions/checkout
+    dependency-version: '7'
+    dependency-type: direct:production
+    update-type: version-update:semver-major
+  ...
+
+
+## 1.0.5 (2026-06-11)
+
 ### Fix
 
 * Rename the action from "Git Flow" to "CBDQ.IO Git Flow" [Ben Dalling]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
         run: echo "RELEASE_CANDIDATE_TAG=$( cat VERSION )" >> $GITHUB_OUTPUT
 
       - name: Git Flow Action
-        uses: cbdq-io/gitflow-action@1.0.5
+        uses: cbdq-io/gitflow-action@1.0.6
         env:
           # Setting this environment variable means we can debug by re-running
           # workflows and ticking "Enable debug logging".


### PR DESCRIPTION
### Build

* Bump actions/checkout from 6 to 7. [dependabot[bot]]

  Bumps [actions/checkout](https://github.com/actions/checkout) from 6 to 7.
  - [Release notes](https://github.com/actions/checkout/releases)
  - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
  - [Commits](https://github.com/actions/checkout/compare/v6...v7)

  ---
  updated-dependencies:
  - dependency-name: actions/checkout
    dependency-version: '7'
    dependency-type: direct:production
    update-type: version-update:semver-major
  ...