### PR TITLE
fix: added exception to skip if triggered by dependabot

### DIFF
--- a/.github/workflows/gitflow.yml
+++ b/.github/workflows/gitflow.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   enforce-git-flow:
+    # Skip if the run was triggered by Dependabot or the branch is dependabot/*
+    if: ${{ github.actor != 'dependabot[bot]' && !startsWith(github.head_ref || '', 'dependabot/') && !startsWith(github.ref, 'refs/heads/dependabot/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Skip if the run was triggered by Dependabot or the branch is dependabot/*.