### PR TITLE
Release/1.0.7

### DIFF
--- a/.github/requirements/requirements.txt
+++ b/.github/requirements/requirements.txt
@@ -2,7 +2,7 @@ click==8.2.1
 fastcore==1.5.33
 ghapi==1.0.5
 gitdb==4.0.11
-GitPython==3.1.57
+GitPython==3.1.58
 joblib==1.5.1
 nltk==3.10.0
 packaging==24.0

--- a/.github/requirements/requirements.txt
+++ b/.github/requirements/requirements.txt
@@ -4,7 +4,7 @@ ghapi==1.0.5
 gitdb==4.0.11
 GitPython==3.1.54
 joblib==1.5.1
-nltk==3.9.4
+nltk==3.10.0
 packaging==24.0
 regex==2024.11.6
 setuptools==83.0.0

--- a/.github/requirements/requirements.txt
+++ b/.github/requirements/requirements.txt
@@ -7,7 +7,7 @@ joblib==1.5.1
 nltk==3.9.4
 packaging==24.0
 regex==2024.11.6
-setuptools==78.1.1
+setuptools==83.0.0
 smmap==5.0.1
 tqdm==4.67.1
 wheel==0.46.2

--- a/.github/requirements/requirements.txt
+++ b/.github/requirements/requirements.txt
@@ -2,7 +2,7 @@ click==8.2.1
 fastcore==1.5.33
 ghapi==1.0.5
 gitdb==4.0.11
-GitPython==3.1.54
+GitPython==3.1.57
 joblib==1.5.1
 nltk==3.10.0
 packaging==24.0

--- a/.github/requirements/requirements.txt
+++ b/.github/requirements/requirements.txt
@@ -2,7 +2,7 @@ click==8.2.1
 fastcore==1.5.33
 ghapi==1.0.5
 gitdb==4.0.11
-GitPython==3.1.50
+GitPython==3.1.54
 joblib==1.5.1
 nltk==3.9.4
 packaging==24.0

--- a/.github/scripts/git_flow.py
+++ b/.github/scripts/git_flow.py
@@ -8,7 +8,7 @@ import nltk
 from fastcore.net import HTTP401UnauthorizedError, HTTP403ForbiddenError
 from ghapi.all import GhApi
 
-__version__ = '1.0.6'
+__version__ = '1.0.7'
 api = GhApi()
 
 

--- a/.github/workflows/gitflow.yml
+++ b/.github/workflows/gitflow.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/gitflow.yml
+++ b/.github/workflows/gitflow.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   enforce-git-flow:
+    # Skip if the run was triggered by Dependabot or the branch is dependabot/*
+    if: ${{ github.actor != 'dependabot[bot]' && !startsWith(github.head_ref || '', 'dependabot/') && !startsWith(github.ref, 'refs/heads/dependabot/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: 3.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,99 @@
 
 ## Unreleased
 
+### Fix
+
+* Added exception to skip if triggered by dependabot. [James Loughlin]
+
+### Build
+
+* Bump gitpython in /.github/requirements. [dependabot[bot]]
+
+  Bumps [gitpython](https://github.com/gitpython-developers/GitPython) from 3.1.57 to 3.1.58.
+  - [Release notes](https://github.com/gitpython-developers/GitPython/releases)
+  - [Changelog](https://github.com/gitpython-developers/GitPython/blob/main/CHANGES)
+  - [Commits](https://github.com/gitpython-developers/GitPython/compare/3.1.57...3.1.58)
+
+  ---
+  updated-dependencies:
+  - dependency-name: gitpython
+    dependency-version: 3.1.58
+    dependency-type: direct:production
+  ...
+
+* Bump gitpython in /.github/requirements. [dependabot[bot]]
+
+  Bumps [gitpython](https://github.com/gitpython-developers/GitPython) from 3.1.54 to 3.1.57.
+  - [Release notes](https://github.com/gitpython-developers/GitPython/releases)
+  - [Changelog](https://github.com/gitpython-developers/GitPython/blob/main/CHANGES)
+  - [Commits](https://github.com/gitpython-developers/GitPython/compare/3.1.54...3.1.57)
+
+  ---
+  updated-dependencies:
+  - dependency-name: gitpython
+    dependency-version: 3.1.57
+    dependency-type: direct:production
+  ...
+
+* Bump nltk from 3.9.4 to 3.10.0 in /.github/requirements. [dependabot[bot]]
+
+  Bumps [nltk](https://github.com/nltk/nltk) from 3.9.4 to 3.10.0.
+  - [Release notes](https://github.com/nltk/nltk/releases)
+  - [Changelog](https://github.com/nltk/nltk/blob/develop/ChangeLog)
+  - [Commits](https://github.com/nltk/nltk/compare/3.9.4...v3.10.0)
+
+  ---
+  updated-dependencies:
+  - dependency-name: nltk
+    dependency-version: 3.10.0
+    dependency-type: direct:production
+  ...
+
+* Bump setuptools in /.github/requirements. [dependabot[bot]]
+
+  Bumps [setuptools](https://github.com/pypa/setuptools) from 78.1.1 to 83.0.0.
+  - [Release notes](https://github.com/pypa/setuptools/releases)
+  - [Changelog](https://github.com/pypa/setuptools/blob/main/NEWS.rst)
+  - [Commits](https://github.com/pypa/setuptools/compare/v78.1.1...v83.0.0)
+
+  ---
+  updated-dependencies:
+  - dependency-name: setuptools
+    dependency-version: 83.0.0
+    dependency-type: direct:production
+  ...
+
+* Bump gitpython in /.github/requirements. [dependabot[bot]]
+
+  Bumps [gitpython](https://github.com/gitpython-developers/GitPython) from 3.1.50 to 3.1.54.
+  - [Release notes](https://github.com/gitpython-developers/GitPython/releases)
+  - [Changelog](https://github.com/gitpython-developers/GitPython/blob/main/CHANGES)
+  - [Commits](https://github.com/gitpython-developers/GitPython/compare/3.1.50...3.1.54)
+
+  ---
+  updated-dependencies:
+  - dependency-name: gitpython
+    dependency-version: 3.1.54
+    dependency-type: direct:production
+  ...
+
+* Bump actions/setup-python from 6 to 7. [dependabot[bot]]
+
+  Bumps [actions/setup-python](https://github.com/actions/setup-python) from 6 to 7.
+  - [Release notes](https://github.com/actions/setup-python/releases)
+  - [Commits](https://github.com/actions/setup-python/compare/v6...v7)
+
+  ---
+  updated-dependencies:
+  - dependency-name: actions/setup-python
+    dependency-version: '7'
+    dependency-type: direct:production
+    update-type: version-update:semver-major
+  ...
+
+
+## 1.0.6 (2026-06-28)
+
 ### Build
 
 * Bump actions/checkout from 6 to 7. [dependabot[bot]]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
         run: echo "RELEASE_CANDIDATE_TAG=$( cat VERSION )" >> $GITHUB_OUTPUT
 
       - name: Git Flow Action
-        uses: cbdq-io/gitflow-action@1.0.6
+        uses: cbdq-io/gitflow-action@1.0.7
         env:
           # Setting this environment variable means we can debug by re-running
           # workflows and ticking "Enable debug logging".


### PR DESCRIPTION
### Fix

* Added exception to skip if triggered by dependabot. [James Loughlin]

### Build

* Bump gitpython in /.github/requirements. [dependabot[bot]]

  Bumps [gitpython](https://github.com/gitpython-developers/GitPython) from 3.1.57 to 3.1.58.
  - [Release notes](https://github.com/gitpython-developers/GitPython/releases)
  - [Changelog](https://github.com/gitpython-developers/GitPython/blob/main/CHANGES)
  - [Commits](https://github.com/gitpython-developers/GitPython/compare/3.1.57...3.1.58)

  ---
  updated-dependencies:
  - dependency-name: gitpython
    dependency-version: 3.1.58
    dependency-type: direct:production
  ...

* Bump gitpython in /.github/requirements. [dependabot[bot]]

  Bumps [gitpython](https://github.com/gitpython-developers/GitPython) from 3.1.54 to 3.1.57.
  - [Release notes](https://github.com/gitpython-developers/GitPython/releases)
  - [Changelog](https://github.com/gitpython-developers/GitPython/blob/main/CHANGES)
  - [Commits](https://github.com/gitpython-developers/GitPython/compare/3.1.54...3.1.57)

  ---
  updated-dependencies:
  - dependency-name: gitpython
    dependency-version: 3.1.57
    dependency-type: direct:production
  ...

* Bump nltk from 3.9.4 to 3.10.0 in /.github/requirements. [dependabot[bot]]

  Bumps [nltk](https://github.com/nltk/nltk) from 3.9.4 to 3.10.0.
  - [Release notes](https://github.com/nltk/nltk/releases)
  - [Changelog](https://github.com/nltk/nltk/blob/develop/ChangeLog)
  - [Commits](https://github.com/nltk/nltk/compare/3.9.4...v3.10.0)

  ---
  updated-dependencies:
  - dependency-name: nltk
    dependency-version: 3.10.0
    dependency-type: direct:production
  ...

* Bump setuptools in /.github/requirements. [dependabot[bot]]

  Bumps [setuptools](https://github.com/pypa/setuptools) from 78.1.1 to 83.0.0.
  - [Release notes](https://github.com/pypa/setuptools/releases)
  - [Changelog](https://github.com/pypa/setuptools/blob/main/NEWS.rst)
  - [Commits](https://github.com/pypa/setuptools/compare/v78.1.1...v83.0.0)

  ---
  updated-dependencies:
  - dependency-name: setuptools
    dependency-version: 83.0.0
    dependency-type: direct:production
  ...

* Bump gitpython in /.github/requirements. [dependabot[bot]]

  Bumps [gitpython](https://github.com/gitpython-developers/GitPython) from 3.1.50 to 3.1.54.
  - [Release notes](https://github.com/gitpython-developers/GitPython/releases)
  - [Changelog](https://github.com/gitpython-developers/GitPython/blob/main/CHANGES)
  - [Commits](https://github.com/gitpython-developers/GitPython/compare/3.1.50...3.1.54)

  ---
  updated-dependencies:
  - dependency-name: gitpython
    dependency-version: 3.1.54
    dependency-type: direct:production
  ...

* Bump actions/setup-python from 6 to 7. [dependabot[bot]]

  Bumps [actions/setup-python](https://github.com/actions/setup-python) from 6 to 7.
  - [Release notes](https://github.com/actions/setup-python/releases)
  - [Commits](https://github.com/actions/setup-python/compare/v6...v7)

  ---
  updated-dependencies:
  - dependency-name: actions/setup-python
    dependency-version: '7'
    dependency-type: direct:production
    update-type: version-update:semver-major
  ...